### PR TITLE
patch: correction in the import.sql add role_id column value

### DIFF
--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -5,8 +5,8 @@
 insert into role (name) values ('ROLE_USER')
 
 --3-2: insert two users
-insert into user (username, enabled, password) values ('user', true, 'password', 1)
-insert into user (username, enabled, password) values ('user2', true, 'password', 1)
+insert into user (username, enabled, password, role_id) values ('user', true, 'password', 1)
+insert into user (username, enabled, password, role_id) values ('user2', true, 'password', 1)
 
 -- Insert tasks
 insert into task (complete,description) values (true,'Code Task entity');


### PR DESCRIPTION
This is a patch due to the missed variable role_id in the import.sql. We can run but with warning at first but after this patch it is initialized seamlessly. Already being tested using boot run.